### PR TITLE
declairing dependency on through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/saebekassebil/microphone-stream/issues"
   },
-  "homepage": "https://github.com/saebekassebil/microphone-stream#readme"
+  "homepage": "https://github.com/saebekassebil/microphone-stream#readme",
+  "dependencies": {
+    "through2": "^2.0.0"
+  }
 }


### PR DESCRIPTION
2.0 is the latest version on https://www.npmjs.com/package/through2 although, based on the notes there, you might want an older version.
