### PR TITLE
Several changes: Binary stream (not object mode), .stop() method, others

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,39 +1,52 @@
-var through2 = require('through2');
+'use strict';
+var Readable = require('stream').Readable;
+var util = require('util');
 
 var micstream = module.exports = function micstream(stream, opts) {
-  var bufferSize = 4096, inputChannels = 2, outputChannels = 2;
+  // "It is recommended for authors to not specify this buffer size and allow the implementation to pick a good
+  // buffer size to balance between latency and audio quality."
+  // https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createScriptProcessor
+  // Possible values: null, 256, 512, 1024, 2048, 4096, 8192, 16384
+  var bufferSize = null;
   opts = opts || {};
 
   bufferSize = opts.bufferSize || bufferSize;
 
-  if (opts.channels)
-    inputChannels = outputChannels = opts.channels;
+    // We can only emit one channel's worth of audio, so only one input. (Who has multiple microphones anyways?)
+  var inputChannels = 1,
+    // And we're not sending any audio back to the WebAudio API, so don't make it set aside resources for that.
+    outputChannels = 0;
 
-  inputChannels = opts.inputChannels || inputChannels;
-  outputChannels = opts.outputChannels || outputChannels;
+  Readable.call(this, opts);
 
-  var consumerStream = through2.obj();
-
+  var self = this;
+  var recording = true;
   function recorderProcess(e) {
-    var input = e.inputBuffer;
-    var output = e.outputBuffer;
-
-    var channels = [];
-    for (var channel = 0; channel < input.numberOfChannels; channel++) {
-      channels.push(input.getChannelData(channel));
+    if (recording) { // onaudioprocess can be called at least once after we've stopped
+      var raw = e.inputBuffer.getChannelData(0); // Float32Array, each sample is a number from -1 to 1
+      var nodebuffer = new Buffer(raw.buffer); // node only accepts buffers or strings for streams, buffers are essentially a Uint8Array
+      self.push(nodebuffer);
     }
-
-    consumerStream.write(channels);
   }
 
-  var context = new window.AudioContext;
+  var context = this.audioContext = new AudioContext();
   var audioInput = context.createMediaStreamSource(stream);
   var recorder = context.createScriptProcessor(bufferSize, inputChannels, outputChannels);
 
-  recorder.onaudioprocess = recorderProcess
+  recorder.onaudioprocess = recorderProcess;
 
   audioInput.connect(recorder);
-  recorder.connect(context.destination);
 
-  return consumerStream;
+  this.stop = function() {
+    stream.getTracks()[0].stop();
+    recorder.disconnect(0);
+    recording = false;
+    self.push(null);
+  };
+}
+util.inherits(micstream, Readable);
+
+micstream.prototype._read = function(/* bytes */) {
+  // no-op, (flow-control doesn't really work on sound)
 };
+


### PR DESCRIPTION
Hey, I work on the IBM Watson team, and I'm putting together a library to use our speech-to-text service in browsers. I took your lib as a base, but made some significant changes to it in order to make it compatible with my needs (mainly, a "standard" binary stream instead of object mode, and a .stop() method).

It's a fairly major, breaking change, so I'd recommend calling this v2.0.0 if you do merge and release it. (And, I totally understand if you don't want to incorporate such a major change. But, I figured I'd at least make it available if you're interested.)

BTW, Node.js Buffers (which is what binary streams pass around) are basically Uint8Arrrays - so to convert it back to a Float32Array for processing you have to do something like this:

``` js
micstream.on('data', function(chunk) {
  var raw = new Float32Array(chunk.buffer); // this now matches what you'd get from  e.inputBuffer.getChannelData(0);
});
```

If merged, this would supersede #2 
