### PR TITLE
fix typeof MediaStream check for older browsers

### DIFF
--- a/microphone-stream.js
+++ b/microphone-stream.js
@@ -18,7 +18,7 @@ var bufferFrom = require('buffer-from');
  */
 function MicrophoneStream(opts) {
   // backwards compatibility - passing in the Stream here will generally not work on iOS 11 Safari
-  if (typeof MediaStream && opts instanceof MediaStream) {
+  if (typeof MediaStream !== 'undefined' && opts instanceof MediaStream) {
     var stream = opts;
     opts = arguments[1] || {};
     opts.stream = stream;


### PR DESCRIPTION
Hi, I noticed the following error in older browsers:

```
Uncaught ReferenceError: MediaStream is not defined
```

The `typeof` operator will always return a string, so `typeof MediaStream` will always be truthy. I've made a small fix to check for `!== 'undefined'`, though I suppose you could check `=== 'function'` instead.