### PR TITLE
Fix closing stream on micStream.stop() to disconnect audio

### DIFF
--- a/microphone-stream.js
+++ b/microphone-stream.js
@@ -77,6 +77,7 @@ function MicrophoneStream(opts) {
    * @param {MediaStream} stream https://developer.mozilla.org/en-US/docs/Web/API/MediaStream
    */
   this.setStream = function(stream) {
+    this.stream = stream;
     audioInput = context.createMediaStreamSource(stream);
     audioInput.connect(recorder);
     recorder.onaudioprocess = recorderProcess;
@@ -92,7 +93,7 @@ function MicrophoneStream(opts) {
       return;
     }
     try {
-      stream.getTracks()[0].stop();
+      this.stream.getTracks()[0].stop();
     } catch (ex) {
       // This fails in some older versions of chrome. Nothing we can do about it.
     }

--- a/test/spec.js
+++ b/test/spec.js
@@ -75,6 +75,20 @@ describe('MicrophoneStream', function() {
       }).catch(done);
     });
 
+    it('should attempt to stop the tracks of the user media stream', function(done) {
+      function getMediaTrackState(stream) {
+        return stream.getTracks()[0].readyState;
+      }
+
+      getUserMedia({audio: true}).then(function(stream) {
+        assert(getMediaTrackState(stream) === 'live');
+        var micStream = new MicrophoneStream(stream);
+        micStream.stop();
+        assert(getMediaTrackState(stream) === 'ended');
+        done();
+      });
+    });
+
     it('should capture audio and emit AudioBuffers with non-0 data when in object mode', function(done) {
       this.timeout(3000);
       getUserMedia({audio: true}).then(function(stream) {


### PR DESCRIPTION
Recent updates in browsers have removed the `stream.stop()` method and require calling `stop()` on the track associated with the stream. Due to this, when I attempt to stop the `MicrophoneStream` object, the browser will still indicate that the stream is active.

This change maintains state of the getUserMedia `stream` so that these tracks can be stopped manually. A test was added to check for this in the future.