### PR TITLE
Expose internal audioInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ document.getElementById('my-start-button').onclick = function() {
   // or pipe it to another stream
   micStream.pipe(/*...*/);
 
+  // Access the internal audioInput for connecting to another nodes
+  micStream.audioInput.connect(/*...*/));
+
   // It also emits a format event with various details (frequency, channels, etc)
   micStream.on('format', function(format) {
     console.log(format);

--- a/src/microphone-stream.js
+++ b/src/microphone-stream.js
@@ -72,7 +72,7 @@ function MicrophoneStream(opts) {
   // other half of workaround for chrome bugs
   recorder.connect(context.destination);
 
-  var audioInput;
+  this.audioInput = null;
 
   /**
    * Set the MediaStream
@@ -87,8 +87,8 @@ function MicrophoneStream(opts) {
    */
   this.setStream = function (stream) {
     this.stream = stream;
-    audioInput = context.createMediaStreamSource(stream);
-    audioInput.connect(recorder);
+    this.audioInput = context.createMediaStreamSource(stream);
+    this.audioInput.connect(recorder);
     recorder.onaudioprocess = recorderProcess;
   };
 
@@ -127,8 +127,8 @@ function MicrophoneStream(opts) {
       // This fails in some older versions of chrome. Nothing we can do about it.
     }
     recorder.disconnect();
-    if (audioInput) {
-      audioInput.disconnect();
+    if (this.audioInput) {
+      this.audioInput.disconnect();
     }
     try {
       context.close(); // returns a promise;

--- a/src/microphone-stream.js
+++ b/src/microphone-stream.js
@@ -72,6 +72,9 @@ function MicrophoneStream(opts) {
   // other half of workaround for chrome bugs
   recorder.connect(context.destination);
 
+  /**
+   * @type {MediaStreamAudioSourceNode}
+   */
   this.audioInput = null;
 
   /**

--- a/test/spec.js
+++ b/test/spec.js
@@ -82,6 +82,19 @@ describe("MicrophoneStream", function () {
         .catch(done);
     });
 
+    it("should expose internal audioInput", function (done) {
+      getUserMedia({ audio: true })
+        .then(function (stream) {
+          var micStream = new MicrophoneStream(stream);
+          assert(
+            micStream.audioInput instanceof MediaStreamAudioSourceNode,
+            "should return a MediaStreamAudioSourceNode"
+          );
+          done();
+        })
+        .catch(done);
+    });
+
     it("should attempt to stop the tracks of the user media stream", function (done) {
       function getMediaTrackState(stream) {
         return stream.getTracks()[0].readyState;

--- a/types/microphone-stream.d.ts
+++ b/types/microphone-stream.d.ts
@@ -37,6 +37,7 @@ declare class MicrophoneStream {
         context: AudioContext;
     }, ...args: any[]);
     context: any;
+    audioInput: any;
     /**
      * Set the MediaStream
      *

--- a/types/microphone-stream.d.ts
+++ b/types/microphone-stream.d.ts
@@ -37,7 +37,10 @@ declare class MicrophoneStream {
         context: AudioContext;
     }, ...args: any[]);
     context: any;
-    audioInput: any;
+    /**
+     * @type {MediaStreamAudioSourceNode}
+     */
+    audioInput: MediaStreamAudioSourceNode;
     /**
      * Set the MediaStream
      *


### PR DESCRIPTION
Fixes #36 by allowing access to the internal `audioInput` node for additional connections.