### PR TITLE
Use setTimeout instead of process.nextTick

### DIFF
--- a/src/microphone-stream.ts
+++ b/src/microphone-stream.ts
@@ -95,7 +95,7 @@ export default class MicrophoneStream extends Readable {
       this.setStream(stream);
     }
 
-    process.nextTick(() => {
+    setTimeout(() => {
       this.emit("format", {
         channels: 1,
         bitDepth: 32,
@@ -103,7 +103,7 @@ export default class MicrophoneStream extends Readable {
         signed: true,
         float: true,
       });
-    });
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
Enables wider compatibility without needing a pollyfill for the global node.js `process` object.

Fixes #60